### PR TITLE
Fixed decrementing iterator for empty vector

### DIFF
--- a/Explorer/src/FileList/FileList.cpp
+++ b/Explorer/src/FileList/FileList.cpp
@@ -2144,7 +2144,8 @@ void FileList::OffsetItr(INT offsetItr, vector<string> & vStrItems)
 
 void FileList::UpdateToolBarElements(void)
 {
-	_pToolBar->enable(_idRedo, _itrPos != _vDirStack.end() - 1);
+	bool canRedo = !_vDirStack.empty() && (_itrPos != _vDirStack.end() - 1);
+	_pToolBar->enable(_idRedo, canRedo);
 	_pToolBar->enable(_idUndo, _itrPos != _vDirStack.begin());
 }
 


### PR DESCRIPTION
When compiling the plugin in debug mode, it will crash on startup (tested with VS2015).
This is because we're trying to decrement an iterator that points into an empty list (a null iterator).
This PR first checks if the list is empty before attempting to decrement the iterator.